### PR TITLE
Various cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.eggs
+*.pyc
+*.sw*
+.*@neomake*.py
+*.egg-info
+*.so
+.tox
+build
+blobs
+blobs.old
+*.fs*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: python
+
+matrix:
+  include:
+     - python: 2.7
+     - python: 3.4
+       allow_failures: true
+     - python: 3.5
+       allow_failures: true
+     - python: 3.6
+       allow_failures: true
+     - python: 3.7
+       allow_failures: true
+       dist: xenial
+     - python: 3.8-dev
+       allow_failures: true
+       dist: xenial
+     - python: pypy
+       allow_failures: true
+     - python: pypy3.5
+       allow_failures: true
+
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,24 @@
 sudo: false
 language: python
+dist: xenial
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8-dev
+  - pypy2.7-6.0
+  - pypy3.5-6.0
 
 matrix:
-  include:
-     - python: 2.7
-     - python: 3.4
-       allow_failures: true
+  allow_failures:
      - python: 3.5
-       allow_failures: true
      - python: 3.6
-       allow_failures: true
      - python: 3.7
-       allow_failures: true
-       dist: xenial
      - python: 3.8-dev
-       allow_failures: true
-       dist: xenial
-     - python: pypy
-       allow_failures: true
-     - python: pypy3.5
-       allow_failures: true
+     - python: pypy2.7-6.0
+     - python: pypy3.5-6.0
 
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Testing
+# Testing [![Build Status](https://travis-ci.org/zopefoundation/zc.FileStorage.svg?branch=master)](https://travis-ci.org/zopefoundation/zc.FileStorage)
 
 So far, `zc.FileStorage` only works with python 2 and ZODB <= 4.
 
-`env TZ=UTC+5 python2 setup.py test`
+Run tests with `env TZ=UTC+5 python2 setup.py test` or `tox`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Testing
+
+So far, `zc.FileStorage` only works with python 2 and ZODB <= 4.
+
+`env TZ=UTC+5 python2 setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[tox:tox]
+envlist = {py27,py34,py35,py36,py37}
+skipsdist=True
+
+[testenv]
+commands = python setup.py test {posargs}
+setenv = TZ = UTC+5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tox:tox]
-envlist = {py27,py34,py35,py36,py37,pypy,pypy3}
-skipsdist=True
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
+skipsdist = True
 
 [testenv]
 commands = python setup.py test {posargs}
-setenv = TZ = UTC+5
+setenv = TZ=UTC+5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tox:tox]
-envlist = {py27,py34,py35,py36,py37}
+envlist = {py27,py34,py35,py36,py37,pypy,pypy3}
 skipsdist=True
 
 [testenv]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(
     namespace_packages = ['zc'],
     package_dir = {'': 'src'},
     install_requires = ['setuptools',
-                        'ZODB3 >=3.9dev'
+                        'ZODB<5',
+                        'ZEO<5',
+                        'transaction<2',
                         ],
     tests_require=[
         'zope.testing',

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,11 @@ setup(
     install_requires = ['setuptools',
                         'ZODB3 >=3.9dev'
                         ],
-    extras_require=dict(
-        test=[
-            'zope.testing',
-            ]),
+    tests_require=[
+        'zope.testing',
+        'mock',
+    ],
+    test_suite="zc.FileStorage.tests.test_suite",
     include_package_data = True,
     zip_safe = False,
     entry_points = entry_points,

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ entry_points = """
 snapshot-in-time = zc.FileStorage.snapshotintime:main
 """
 
+tests_requirements = [
+    'zope.testing',
+    'mock',
+]
+
 setup(
     name = name,
     version = version,
@@ -27,10 +32,10 @@ setup(
                         'ZEO<5',
                         'transaction<2',
                         ],
-    tests_require=[
-        'zope.testing',
-        'mock',
-    ],
+    tests_require=tests_requirements,
+    extras_require=dict(
+        test=tests_requirements,
+    ),
     test_suite="zc.FileStorage.tests.test_suite",
     include_package_data = True,
     zip_safe = False,

--- a/src/zc/FileStorage/__init__.py
+++ b/src/zc/FileStorage/__init__.py
@@ -379,7 +379,7 @@ class PackProcess(FileStoragePacker):
 
     def buildPackIndex(self, stop, file_end):
         index = ZODB.fsIndex.fsIndex()
-        pos = 4L
+        pos = 4
         packed = True
         log_pos = pos
 
@@ -442,7 +442,7 @@ class PackProcess(FileStoragePacker):
         while pos < packpos:
             start_time = time.time()
             th = self._read_txn_header(pos)
-            new_tpos = 0L
+            new_tpos = 0
             tend = pos + th.tlen
             pos += th.headerlen()
             while pos < tend:

--- a/src/zc/FileStorage/__init__.py
+++ b/src/zc/FileStorage/__init__.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 
+from __future__ import absolute_import
+
 import cPickle
 import logging
 import os
@@ -565,7 +567,7 @@ def _freefunc(f):
     # Return an posix_fadvise-based cache freeer.
 
     try:
-        import _zc_FileStorage_posix_fadvise
+        from . import _zc_FileStorage_posix_fadvise
     except ImportError:
         return lambda pos: None
 

--- a/src/zc/FileStorage/__init__.py
+++ b/src/zc/FileStorage/__init__.py
@@ -157,7 +157,7 @@ class FileStoragePacker(FileStorageFormatter):
                     input_pos = self._copyNewTrans(
                         input_pos, output, index,
                         self._commit_lock_acquire, self._commit_lock_release)
-            except CorruptedDataError, err:
+            except CorruptedDataError as err:
                 # The last call to copyOne() will raise
                 # CorruptedDataError, because it will attempt to read past
                 # the end of the file.  Double-check that the exception
@@ -271,7 +271,7 @@ try:
                                         %(blob_dir)r, %(sleep)s,
                                         %(transform)r, %(untransform)r)
     packer.pack()
-except Exception, v:
+except Exception as v:
     logging.exception('packing')
     try:
         v = cPickle.dumps(v)

--- a/src/zc/FileStorage/__init__.py
+++ b/src/zc/FileStorage/__init__.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import cPickle
 import logging
 import os
 import subprocess
@@ -29,6 +28,11 @@ import ZODB.FileStorage
 import ZODB.FileStorage.fspack
 import ZODB.fsIndex
 import ZODB.TimeStamp
+
+if sys.version_info.major == 2:
+    import cPickle as pickle
+else:
+    import pickle
 
 GIG = 1<<30
 
@@ -108,7 +112,7 @@ class FileStoragePacker(FileStorageFormatter):
         out = proc.stdout.read()
         if proc.wait():
             if os.path.exists(self._name+'.packerror'):
-                v = cPickle.Unpickler(open(self._name+'.packerror', 'rb')
+                v = pickle.Unpickler(open(self._name+'.packerror', 'rb')
                                       ).load()
                 os.remove(self._name+'.packerror')
                 raise v
@@ -119,7 +123,7 @@ class FileStoragePacker(FileStorageFormatter):
         if not os.path.exists(packindex_path):
             return # already packed or pack didn't benefit
 
-        index, opos = cPickle.Unpickler(open(packindex_path, 'rb')).load()
+        index, opos = pickle.Unpickler(open(packindex_path, 'rb')).load()
         os.remove(packindex_path)
         os.remove(self._name+".packscript")
 
@@ -259,7 +263,11 @@ import sys, logging
 
 sys.path[:] = %(syspath)r
 
-import cPickle
+if sys.version_info.major == 2:
+    import cPickle as pickle
+else:
+    import pickle
+
 import zc.FileStorage
 
 logging.getLogger().setLevel(logging.INFO)
@@ -276,7 +284,7 @@ try:
 except Exception as v:
     logging.exception('packing')
     try:
-        v = cPickle.dumps(v)
+        v = pickle.dumps(v)
     except Exception:
         pass
     else:
@@ -360,7 +368,7 @@ class PackProcess(FileStoragePacker):
 
         # Save the index so the parent process can use it as a starting point.
         f = open(self._name + ".packindex", 'wb')
-        cPickle.Pickler(f, 1).dump((index, output.tell()))
+        pickle.Pickler(f, 1).dump((index, output.tell()))
         f.close()
         output.flush()
         os.fsync(output.fileno())

--- a/src/zc/FileStorage/snapshotintime.py
+++ b/src/zc/FileStorage/snapshotintime.py
@@ -72,7 +72,7 @@ def main(args=None):
             hour, minute, second = (map(int, time.split(':'))+[0,0])[:3]
         else:
             hour = minute = second = 0
-        stop = repr(ZODB.TimeStamp.TimeStamp(year, month, day, hour, minute, second)).replace("'", "").decode("string_escape")
+        stop = ZODB.TimeStamp.TimeStamp(year, month, day, hour, minute, second).raw()
 
     except Exception:
         print('Bad date-time:', stop, file=sys.stderr)

--- a/src/zc/FileStorage/snapshotintime.py
+++ b/src/zc/FileStorage/snapshotintime.py
@@ -72,9 +72,8 @@ def main(args=None):
             hour, minute, second = (map(int, time.split(':'))+[0,0])[:3]
         else:
             hour = minute = second = 0
-        stop = repr(
-            ZODB.TimeStamp.TimeStamp(year, month, day, hour, minute, second)
-            )
+        stop = repr(ZODB.TimeStamp.TimeStamp(year, month, day, hour, minute, second)).replace("'", "").decode("string_escape")
+
     except Exception:
         print('Bad date-time:', stop, file=sys.stderr)
         sys.exit(1)

--- a/src/zc/FileStorage/snapshotintime.py
+++ b/src/zc/FileStorage/snapshotintime.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -42,7 +44,7 @@ def main(args=None):
         args = sys.argv[1:]
 
     if len(args) < 2 or len(args) > 3:
-        print >>sys.stderr, usage % sys.argv[0]
+        print(usage % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
 
@@ -56,11 +58,11 @@ def main(args=None):
             else:
                 outpath = inpath+stop
     except ValueError:
-        print >>sys.stderr, usage % sys.argv[0]
+        print(usage % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
     if not os.path.exists(inpath):
-        print >>sys.stderr, inpath, 'Does not exist.'
+        print(inpath, 'Does not exist.', file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -74,7 +76,7 @@ def main(args=None):
             ZODB.TimeStamp.TimeStamp(year, month, day, hour, minute, second)
             )
     except Exception:
-        print >>sys.stderr, 'Bad date-time:', stop
+        print('Bad date-time:', stop, file=sys.stderr)
         sys.exit(1)
 
     zc.FileStorage.PackProcess(inpath, stop, os.stat(inpath).st_size

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -459,7 +459,7 @@ def snapshot_in_time():
 
     >>> conn.close()
     >>> conn = ZODB.connection('snapshot.fs')
-    >>> sorted(conn.root().iterkeys()) == range(5)
+    >>> sorted(conn.root().keys()) == range(5)
     True
 
     >>> for i in range(5):

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -388,6 +388,7 @@ def snapshot_in_time():
     Next, we'll create a file storage with some data:
 
     >>> import ZODB.FileStorage
+    >>> import transaction
 
     >>> conn = ZODB.connection('data.fs')
     >>> for i in range(5):

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -129,7 +129,7 @@ def faux_time():
     return now
 
 def faux_sleep(x):
-    logging.info('sleep '+`x`)
+    logging.info('sleep '+ repr(x))
 
 time.time, time.sleep = faux_time, faux_sleep
 """
@@ -177,7 +177,7 @@ Mess with time -- there should be infrastructure for this!
     ...        break
     ...     time.sleep(0.01)
     >>> def faux_sleep(x):
-    ...     print('sleep '+`x`)
+    ...     print('sleep '+repr(x))
     >>> time.sleep = faux_sleep
     >>> conn.root().x = 1
     >>> transaction.commit()
@@ -440,7 +440,7 @@ def snapshot_in_time():
     >>> for t in ZODB.FileStorage.FileIterator('snapshot.fs'):
     ...     print (ZODB.TimeStamp.TimeStamp(t.tid))
     ...     for record in t:
-    ...         print (`record.oid`)
+    ...         print (repr(record.oid))
     2010-03-09 20:28:05.000000
     '\x00\x00\x00\x00\x00\x00\x00\x00'
     2010-03-09 20:28:56.000000

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -177,7 +177,7 @@ Mess with time -- there should be infrastructure for this!
     ...        break
     ...     time.sleep(0.01)
     >>> def faux_sleep(x):
-    ...     print 'sleep '+`x`
+    ...     print('sleep '+`x`)
     >>> time.sleep = faux_sleep
     >>> conn.root().x = 1
     >>> transaction.commit()
@@ -185,7 +185,7 @@ Mess with time -- there should be infrastructure for this!
     sleep 1.0
 
     >>> fs.close()
-    >>> print open('data.fs.packlog').read(), # doctest: +NORMALIZE_WHITESPACE
+    >>> print (open('data.fs.packlog').read(),) # doctest: +NORMALIZE_WHITESPACE
     2010-03-09 15:27:55,000 root INFO packing to 2010-03-09 20:28:06.000000,
        sleep 1
     2010-03-09 15:27:57,000 root INFO read 162
@@ -241,7 +241,7 @@ Now do it all again with a longer sleep:
     >>> fs = ZODB.FileStorage.FileStorage('data.fs',
     ...                                   packer=zc.FileStorage.packer2)
     >>> fs.pack(pack_time, now)
-    >>> print open('data.fs.packlog').read(), # doctest: +NORMALIZE_WHITESPACE
+    >>> print (open('data.fs.packlog').read(),) # doctest: +NORMALIZE_WHITESPACE
     2010-03-09 15:27:55,000 root INFO packing to 2010-03-09 20:28:06.000000,
       sleep 2
     2010-03-09 15:27:57,000 root INFO read 162
@@ -360,7 +360,7 @@ Now pack and make sure all the records have been transformed:
     >>> from ZODB.utils import p64
     >>> for i in range(len(db.storage)):
     ...     if db.storage.load(p64(i))[0][:2] != '.h':
-    ...         print i
+    ...         print (i)
 
 We should have only one blob file:
 
@@ -438,9 +438,9 @@ def snapshot_in_time():
     The new file has just the final records:
 
     >>> for t in ZODB.FileStorage.FileIterator('snapshot.fs'):
-    ...     print ZODB.TimeStamp.TimeStamp(t.tid)
+    ...     print (ZODB.TimeStamp.TimeStamp(t.tid))
     ...     for record in t:
-    ...         print `record.oid`
+    ...         print (`record.oid`)
     2010-03-09 20:28:05.000000
     '\x00\x00\x00\x00\x00\x00\x00\x00'
     2010-03-09 20:28:56.000000
@@ -463,7 +463,7 @@ def snapshot_in_time():
 
     >>> for i in range(5):
     ...     if conn.root()[i].x != 10:
-    ...         print 'oops', conn.root()[i].x
+    ...         print ('oops', conn.root()[i].x)
 
     >>> time.time, time.sleep = time_time, time_sleep
 
@@ -476,7 +476,7 @@ def snapshot_in_time():
     >>> sys.argv[0] = 'snapshot-in-time'
     >>> try: zc.FileStorage.snapshotintime.main([])
     ... except SystemExit, v: pass
-    ... else: print 'oops'
+    ... else: print ('oops')
     Usage: snapshot-in-time [input-path utc-snapshot-time output-path]
     <BLANKLINE>
     Make a point-in time snapshot of a file-storage data file containing
@@ -498,12 +498,12 @@ def snapshot_in_time():
 
     >>> try: zc.FileStorage.snapshotintime.main(['xxx', 'xxx', 'xxx'])
     ... except SystemExit, v: pass
-    ... else: print 'oops'
+    ... else: print ('oops')
     xxx Does not exist.
 
     >>> try: zc.FileStorage.snapshotintime.main(['data.fs', 'xxx', 'xxx'])
     ... except SystemExit, v: pass
-    ... else: print 'oops'
+    ... else: print ('oops')
     Bad date-time: xxx
 
     >>> sys.stderr = stderr

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -475,7 +475,7 @@ def snapshot_in_time():
     >>> argv0 = sys.argv[0]
     >>> sys.argv[0] = 'snapshot-in-time'
     >>> try: zc.FileStorage.snapshotintime.main([])
-    ... except SystemExit, v: pass
+    ... except SystemExit as v: pass
     ... else: print ('oops')
     Usage: snapshot-in-time [input-path utc-snapshot-time output-path]
     <BLANKLINE>
@@ -497,12 +497,12 @@ def snapshot_in_time():
     >>> sys.argv[0] = argv0
 
     >>> try: zc.FileStorage.snapshotintime.main(['xxx', 'xxx', 'xxx'])
-    ... except SystemExit, v: pass
+    ... except SystemExit as v: pass
     ... else: print ('oops')
     xxx Does not exist.
 
     >>> try: zc.FileStorage.snapshotintime.main(['data.fs', 'xxx', 'xxx'])
-    ... except SystemExit, v: pass
+    ... except SystemExit as v: pass
     ... else: print ('oops')
     Bad date-time: xxx
 

--- a/src/zc/FileStorage/tests.py
+++ b/src/zc/FileStorage/tests.py
@@ -185,7 +185,7 @@ Mess with time -- there should be infrastructure for this!
     sleep 1.0
 
     >>> fs.close()
-    >>> print (open('data.fs.packlog').read(),) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(open('data.fs.packlog').read()) # doctest: +NORMALIZE_WHITESPACE
     2010-03-09 15:27:55,000 root INFO packing to 2010-03-09 20:28:06.000000,
        sleep 1
     2010-03-09 15:27:57,000 root INFO read 162
@@ -241,7 +241,7 @@ Now do it all again with a longer sleep:
     >>> fs = ZODB.FileStorage.FileStorage('data.fs',
     ...                                   packer=zc.FileStorage.packer2)
     >>> fs.pack(pack_time, now)
-    >>> print (open('data.fs.packlog').read(),) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(open('data.fs.packlog').read()) # doctest: +NORMALIZE_WHITESPACE
     2010-03-09 15:27:55,000 root INFO packing to 2010-03-09 20:28:06.000000,
       sleep 2
     2010-03-09 15:27:57,000 root INFO read 162
@@ -360,7 +360,7 @@ Now pack and make sure all the records have been transformed:
     >>> from ZODB.utils import p64
     >>> for i in range(len(db.storage)):
     ...     if db.storage.load(p64(i))[0][:2] != '.h':
-    ...         print (i)
+    ...         print(i)
 
 We should have only one blob file:
 
@@ -439,9 +439,9 @@ def snapshot_in_time():
     The new file has just the final records:
 
     >>> for t in ZODB.FileStorage.FileIterator('snapshot.fs'):
-    ...     print (ZODB.TimeStamp.TimeStamp(t.tid))
+    ...     print(ZODB.TimeStamp.TimeStamp(t.tid))
     ...     for record in t:
-    ...         print (repr(record.oid))
+    ...         print(repr(record.oid))
     2010-03-09 20:28:05.000000
     '\x00\x00\x00\x00\x00\x00\x00\x00'
     2010-03-09 20:28:56.000000
@@ -464,7 +464,7 @@ def snapshot_in_time():
 
     >>> for i in range(5):
     ...     if conn.root()[i].x != 10:
-    ...         print ('oops', conn.root()[i].x)
+    ...         print('oops', conn.root()[i].x)
 
     >>> time.time, time.sleep = time_time, time_sleep
 
@@ -477,7 +477,7 @@ def snapshot_in_time():
     >>> sys.argv[0] = 'snapshot-in-time'
     >>> try: zc.FileStorage.snapshotintime.main([])
     ... except SystemExit as v: pass
-    ... else: print ('oops')
+    ... else: print('oops')
     Usage: snapshot-in-time [input-path utc-snapshot-time output-path]
     <BLANKLINE>
     Make a point-in time snapshot of a file-storage data file containing
@@ -499,12 +499,12 @@ def snapshot_in_time():
 
     >>> try: zc.FileStorage.snapshotintime.main(['xxx', 'xxx', 'xxx'])
     ... except SystemExit as v: pass
-    ... else: print ('oops')
+    ... else: print('oops')
     xxx Does not exist.
 
     >>> try: zc.FileStorage.snapshotintime.main(['data.fs', 'xxx', 'xxx'])
     ... except SystemExit as v: pass
-    ... else: print ('oops')
+    ... else: print('oops')
     Bad date-time: xxx
 
     >>> sys.stderr = stderr


### PR DESCRIPTION
This pull requests does various things:
- Fixed tests with `env TZ=UTC+5 python2 setup.py test`
- Add travis support (tests python 2.7 and everything from python 3.4 to 3.8-dev)
- A bit of python 3 compatibility (avoid repr backtick syntax, new print function etc...)

So the point is to check that python 2 tests are still valid, as a base to make them work with python 3.